### PR TITLE
Add Python Support for .pcube file format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # custom ignores to prevent including cubes files
 *.npy
+*.pcube
 
 # custom ignores to prevent vscode files being included
 .vscode

--- a/python/converter.py
+++ b/python/converter.py
@@ -1,0 +1,44 @@
+from libraries.pcube import read, write, Orientation, Compression
+from libraries.packing import pack, unpack
+import numpy as np
+import argparse
+
+def npy_to_pcube(infile, outfile, orientation, compress):
+    cubes = np.load(infile, allow_pickle=True)
+    packed = [pack(cube) for cube in cubes]
+    write(outfile, orientation, packed, compress)
+
+def pcube_to_npy(infile, outfile):
+    result = read(infile)
+    unpacked = [unpack(cube) for cube in result.polycubes]
+    np.save(outfile, unpacked)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog='Pollycube Converter',
+        description='Converts .npy files into .pcube files and vice versa')
+
+    parser.add_argument('filename', metavar='File Name', type=str,
+                        help='The File to convert')
+    parser.add_argument('--compress', dest='compress', action='append', type=int, default=0, choices=[0,1],
+                        help='whether to compress the cubes if writing to the pcubes format, options are: 0: no compression 1: gzip compression')
+    parser.add_argument('--orientation', dest='orientation', action='append', type=int, default=0, choices=[0,1],
+                        help='whether the cubes are oriented, options are: 0: unoriented 1: orientated by bitwise highest value')
+    args = parser.parse_args()
+
+    filename: str = args.filename
+    compress: Compression = Compression(args.compress)
+    orientation: Orientation = Orientation(args.orientation)
+
+    with open(filename, 'rb') as fp:
+        if(filename.endswith('.npy')):
+            output_file_name = filename.removesuffix('.npy') + '.pcube'
+            with open(output_file_name, 'xb') as ofp:
+                npy_to_pcube(fp, ofp, orientation, compress)
+        elif(filename.endswith('.pcube')):
+            output_file_name = filename.removesuffix('.pcube') + '.npy'
+            with open(output_file_name, 'xb') as ofp:
+                pcube_to_npy(fp, ofp)
+        else:
+            print(f'unkown file extension on file {filename}')
+

--- a/python/libraries/pcube.py
+++ b/python/libraries/pcube.py
@@ -1,0 +1,88 @@
+from enum import Enum
+from io import IOBase
+from dataclasses import dataclass
+from typing import Generator
+import leb128
+import math
+from io import BytesIO
+import gzip
+
+magic_string = bytes.fromhex('CBECCBEC')
+
+class Orientation(Enum):
+    UNSORTED = 0
+    BITWISE_HIGHEST_VALUE = 1
+
+class Compression(Enum):
+    NO_COMPRESSION = 0
+    GZIP_COMPRESSION = 1
+
+@dataclass
+class Polycubes():
+    orientation: Orientation
+    polycubes: list[bytes]
+
+vlq_num_mask = 0b01111111
+vlq_continue_mask = 1<<7
+
+def vlq_is_complete(byte) -> bool:
+    return (byte | vlq_continue_mask)
+
+def write(fp: IOBase, orientation: Orientation, polycubes: list[bytes], compression: Compression = Compression.NO_COMPRESSION) -> None:
+    header = magic_string
+    header += int(orientation.value).to_bytes(1, 'little')
+    header += int(compression.value).to_bytes(1, 'little')
+    header += leb128.u.encode(len(polycubes))
+    fp.write(header)
+    if(compression == Compression.GZIP_COMPRESSION):
+        total_data = bytearray()
+        for polycube in polycubes:
+            total_data.extend(polycube)
+        fp.write(gzip.compress(total_data, 5))
+    else:
+        for polycube in polycubes:
+            fp.write(polycube)
+
+def read_block(fp: IOBase) -> bytes:
+    shape = fp.read(3)
+    size = math.ceil((shape[0] * shape[1] * shape[2]) / 8)
+    body = fp.read(size)
+    return shape + body
+
+
+def read(fp: IOBase, ignore_orientation:bool = False) -> Polycubes:
+    magic = fp.read(4)
+    if(magic != magic_string):
+        raise ValueError("provided file does not have a valid pcube header")
+    
+    orientation = int.from_bytes(fp.read(1),'little')
+    if(ignore_orientation):
+        orientation = 0
+    else:
+        if(orientation not in [e.value for e in Orientation]):
+            raise ValueError("provided file uses unsuported orientations")
+    orientation = Orientation(orientation)
+
+    compression = int.from_bytes(fp.read(1), 'little')
+    if(compression not in [e.value for e in Compression]):
+        raise ValueError("provided file uses unsuported compression")
+    compression = Compression(compression)
+    
+    n_cubes, read = leb128.u.decode_reader(fp)
+
+    use_fp = fp
+    if (compression == Compression.GZIP_COMPRESSION):
+        use_fp = BytesIO()
+        use_fp.write(gzip.decompress(fp.read()))
+        use_fp.seek(0)
+
+    cubes = []
+
+    if(n_cubes == 0):
+        while(fp.readable()):
+            cubes.append(read_block(use_fp))
+    else:
+        for n in range(0, n_cubes):
+            cubes.append(read_block(use_fp))
+    
+    return Polycubes(orientation=orientation, polycubes=cubes)

--- a/python/tests/test_pcube.py
+++ b/python/tests/test_pcube.py
@@ -1,0 +1,28 @@
+import unittest
+from libraries.packing import pack
+from libraries.pcube import read, write, Orientation, Compression
+from io import BytesIO
+from utils import get_test_data
+
+class PcubeTests(unittest.TestCase):
+    def test_pcube_integrity(self):
+        test_data = get_test_data()
+        packed = [pack(cube) for cube in test_data]
+        
+        with BytesIO() as pcube_stream:
+            write(pcube_stream, polycubes=packed, orientation=Orientation.UNSORTED, compression=Compression.NO_COMPRESSION)
+            pcube_stream.seek(0)
+            result = read(pcube_stream)
+        
+        self.assertEqual(packed, result.polycubes)
+
+    def test_pcube_compressed_integrity(self):
+        test_data = get_test_data()
+        packed = [pack(cube) for cube in test_data]
+        
+        with BytesIO() as pcube_stream:
+            write(pcube_stream, polycubes=packed, orientation=Orientation.UNSORTED, compression=Compression.GZIP_COMPRESSION)
+            pcube_stream.seek(0)
+            result = read(pcube_stream)
+        
+        self.assertEqual(packed, result.polycubes)

--- a/python/tests/test_pcube.py
+++ b/python/tests/test_pcube.py
@@ -2,7 +2,7 @@ import unittest
 from libraries.packing import pack
 from libraries.pcube import read, write, Orientation, Compression
 from io import BytesIO
-from utils import get_test_data
+from .utils import get_test_data
 
 class PcubeTests(unittest.TestCase):
     def test_pcube_integrity(self):


### PR DESCRIPTION
Add a converter tool to convert to and from .pcube file format to and from .npy.
this format is also supported by the rust implementation so this would make the two compatible.

format specification:
```
extension : .pcube
data: binary
header:
[4 bytes] [byte]      [byte]      [bytes...] [bytes...]
magic     orientation compression cube_count body

  [4 bytes] magic:
    for uniquely identifying this format, takes the raw hex value
    0xCBECCBEC
  
  [byte] orientation:
    allows for different future canonical orientations current options are:
      0 : UNSORTED : these are random rotations rotate them yourself to get whatever your canonical rotations are.
      1 : BITWISE_HIGHEST_VALUE: the rotation of the cube which has the highest value when compared byte by byte in the cube format (see body format for details):
    more orientations can be added if better methods for finding identical rotations are found.
  
  [byte] compression:
    indicates whether the body data is compressed:
      0: uncompressed data stream
      1: gzip compressed data stream

  [bytes...] cube_count:
    a LEB128 encoded arbitrarily large unsigned integer representing the number of cubes in this file / stream (https://en.wikipedia.org/wiki/LEB128).
    0 indicates that this is a variable length file / stream and will simply abruptly end.
  
  [bytes...] body:
   a set of data blocks for each cube where each block takes the form:
      x     y     z     data
      [byte][byte][byte][bytes...]
  
      [byte] x:
        an 8 bit unsigned integer representing the cubes x dimension
      [byte] y:
        an 8 bit unsigned integer representing the cubes x dimension
      [byte] z:
        an 8 bit unsigned integer representing the cubes x dimension
      [bytes...] data:
        the flattened bits of the polycube where 1 is a filled space and 0 is empty, flattened in row-major (C-style), stored in little endian, padded to the nearest byte with zeros.
```

I think its also worth changing over the base application cubes.py to use this file format as it is significantly smaller. but didn't want to initially include it here until the format and converter where reviewed.