### PR TITLE
C++ | Splitting work by output shape

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(CubeObjs OBJECT
 	"src/cubes.cpp"
 	"src/cache.cpp"
 	"src/rotations.cpp"
+	"src/newCache.cpp"
 )
 ConfigureTarget(CubeObjs)
 

--- a/cpp/include/cache.hpp
+++ b/cpp/include/cache.hpp
@@ -25,8 +25,11 @@ struct Cache {
         uint64_t size;     // in bytes should be multiple of XYZ_SIZE
     };
 
-    static void save(std::string path, Hashy &hashes, uint8_t n);
+    static void save(std::string path, Hashy& hashes, uint8_t n);
     static Hashy load(std::string path, uint32_t extractShape = ALL_SHAPES);
+
+    int filedesc;
+    void* mmap_ptr;
 };
 
 #endif

--- a/cpp/include/cube.hpp
+++ b/cpp/include/cube.hpp
@@ -25,6 +25,16 @@ struct XYZ {
     constexpr int8_t z() const { return data[2]; }
     constexpr int8_t &operator[](int offset) { return data[offset]; }
     constexpr int8_t operator[](int offset) const { return data[offset]; }
+    friend XYZ operator+(const XYZ &a, const XYZ &b) {
+        XYZ ret = a;
+        ret += b;
+        return ret;
+    }
+    void operator+=(const XYZ &b) {
+        data[0] += b.data[0];
+        data[1] += b.data[1];
+        data[2] += b.data[2];
+    }
 };
 
 struct HashXYZ {

--- a/cpp/include/cubes.hpp
+++ b/cpp/include/cubes.hpp
@@ -4,5 +4,5 @@
 
 #include "hashes.hpp"
 
-Hashy gen(int n, int threads = 1, bool use_cache = false, bool write_cache = false);
+Hashy gen(int n, int threads = 1, bool use_cache = false, bool write_cache = false, bool split_cache = false);
 #endif

--- a/cpp/include/cubes.hpp
+++ b/cpp/include/cubes.hpp
@@ -3,6 +3,7 @@
 #define OPENCUBES_CUBES_HPP
 
 #include "hashes.hpp"
+#include "newCache.hpp"
 
-Hashy gen(int n, int threads = 1, bool use_cache = false, bool write_cache = false, bool split_cache = false);
+FlatCache gen(int n, int threads = 1, bool use_cache = false, bool write_cache = false, bool split_cache = false);
 #endif

--- a/cpp/include/hashes.hpp
+++ b/cpp/include/hashes.hpp
@@ -69,7 +69,7 @@ struct Hashy {
         }
     };
 
-    std::map<XYZ, Subhashy<8>> byshape;
+    std::map<XYZ, Subhashy<32>> byshape;
     void init(int n) {
         // create all subhashy which will be needed for N
         for (int x = 0; x < n; ++x)

--- a/cpp/include/newCache.hpp
+++ b/cpp/include/newCache.hpp
@@ -1,0 +1,134 @@
+#pragma once
+#ifndef OPENCUBES_NEWCACHE_HPP
+#define OPENCUBES_NEWCACHE_HPP
+#include <cstring>
+#include <string>
+
+#include "cube.hpp"
+
+struct CubeView {
+    uint32_t n;
+    const XYZ* sparse;
+    void print() const {
+        for (uint32_t i = 0; i < n; ++i) {
+            printf("(%2d %2d %2d) ", sparse[i].x(), sparse[i].y(), sparse[i].z());
+        }
+        printf("\n");
+    }
+    operator Cube() const {
+        Cube ret(n);
+        memcpy(ret.data(), sparse, n * sizeof(XYZ));
+        return ret;
+    }
+};
+class Workset;
+struct CubeIterator {
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = CubeView;
+    using pointer = CubeView*;    // or also value_type*
+    using reference = CubeView&;  // or also value_type&
+
+   public:
+    // constructor
+    CubeIterator(uint32_t n, uint8_t* ptr) : n(n), m_ptr(ptr) {}
+
+    // operators
+    const value_type operator*() const {
+        value_type ret{n, (XYZ*)m_ptr};
+        return ret;
+    }
+    // pointer operator->() { return (pointer)m_ptr; }
+
+    // Prefix increment
+    CubeIterator& operator++() {
+        m_ptr += 3 * n;
+        return *this;
+    }
+    CubeIterator& operator+=(int incr) {
+        m_ptr += 3 * n * incr;
+        return *this;
+    }
+
+    // Postfix increment
+    CubeIterator operator++(int) {
+        CubeIterator tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+
+    friend bool operator==(const CubeIterator& a, const CubeIterator& b) { return a.m_ptr == b.m_ptr; };
+    friend bool operator<(const CubeIterator& a, const CubeIterator& b) { return a.m_ptr < b.m_ptr; };
+    friend bool operator>(const CubeIterator& a, const CubeIterator& b) { return a.m_ptr > b.m_ptr; };
+    friend bool operator!=(const CubeIterator& a, const CubeIterator& b) { return a.m_ptr != b.m_ptr; };
+    friend class Workset;
+
+   private:
+    uint32_t n;
+    uint8_t* m_ptr;
+};
+struct ShapeRange {
+    CubeIterator begin() { return b; }
+    CubeIterator end() { return e; }
+
+    CubeIterator b, e;
+    uint64_t size;
+    XYZ shape;
+};
+class CacheReader {
+   public:
+    // constructor
+    explicit CacheReader(const std::string& path);
+    // destuctor
+    ~CacheReader();
+
+    // methods
+    void printHeader();
+    int printShapes();
+    int loadFile(std::string path);
+
+    // vars
+    char* data;
+    uint8_t* filePointer;
+    static constexpr uint32_t MAGIC = 0x42554350;
+    static constexpr uint32_t XYZ_SIZE = 3;
+    static constexpr uint32_t ALL_SHAPES = -1;
+
+    struct Header {
+        uint32_t magic = MAGIC;  // shoud be "PCUB" = 0x42554350
+        uint32_t n;              // we will never need 32bit but it is nicely aligned
+        uint32_t numShapes;      // defines length of the shapeTable
+        uint64_t numPolycubes;   // total number of polycubes
+    };
+    struct ShapeEntry {
+        uint8_t dim0;      // offset by -1
+        uint8_t dim1;      // offset by -1
+        uint8_t dim2;      // offset by -1
+        uint8_t reserved;  // for alignment
+        uint64_t offset;   // from beginning of file
+        uint64_t size;     // in bytes should be multiple of XYZ_SIZE
+    };
+
+    CubeIterator begin() { return CubeIterator(header->n, filePointer + shapes[0].offset); }
+    CubeIterator end() { return CubeIterator(header->n, filePointer + shapes[0].offset + header->n * 3 * 3); }
+
+    ShapeRange getCubesByShape(uint32_t i) {
+        if (i >= header->numShapes) return {CubeIterator(header->n, 0), CubeIterator(header->n, 0), 0, XYZ(0, 0, 0)};
+        return {CubeIterator(header->n, filePointer + shapes[i].offset), CubeIterator(header->n, filePointer + shapes[i].offset + shapes[i].size),
+                shapes[i].size / (header->n * sizeof(XYZ)), XYZ(shapes[i].dim0, shapes[i].dim1, shapes[i].dim2)};
+    }
+    auto size() { return header->numPolycubes; };
+    auto numShapes() { return header->numShapes; };
+
+   private:
+    // private vars
+    std::string path_;
+    int fileDescriptor_;
+    uint64_t fileSize_;
+    bool fileLoaded_;
+    Header dummyHeader;
+    Header* header;
+    ShapeEntry* shapes;
+};
+
+#endif

--- a/cpp/include/newCache.hpp
+++ b/cpp/include/newCache.hpp
@@ -110,7 +110,7 @@ class CacheReader {
     };
 
     CubeIterator begin() { return CubeIterator(header->n, filePointer + shapes[0].offset); }
-    CubeIterator end() { return CubeIterator(header->n, filePointer + shapes[0].offset + header->n * 3 * 3); }
+    CubeIterator end() { return CubeIterator(header->n, filePointer + shapes[0].offset + header->numPolycubes * header->n * 3); }
 
     ShapeRange getCubesByShape(uint32_t i) {
         if (i >= header->numShapes) return {CubeIterator(header->n, 0), CubeIterator(header->n, 0), 0, XYZ(0, 0, 0)};

--- a/cpp/include/results.hpp
+++ b/cpp/include/results.hpp
@@ -2,7 +2,16 @@
 #ifndef OPENCUBES_RESULTS_HPP
 #define OPENCUBES_RESULTS_HPP
 #include <cstdint>
+#include <cstdio>
+
 // from http://kevingong.com/Polyominoes/Enumeration.html
 uint64_t results[] = {1, 1, 2, 8, 29, 166, 1023, 6922, 48311, 346543, 2522522, 18598427, 138462649, 1039496297, 7859514470, 59795121480};
-
+static void checkResult(uint32_t n, uint64_t count) {
+    if (sizeof(results) / sizeof(results[0]) > ((uint64_t)(n - 1)) && n > 1) {
+        if (results[n - 1] != count) {
+            std::printf("ERROR: result does not equal resultstable (%lu)!\n\r", results[n - 1]);
+            std::exit(-1);
+        }
+    }
+}
 #endif

--- a/cpp/program.cpp
+++ b/cpp/program.cpp
@@ -8,12 +8,13 @@ void configure_arguments(cli::Parser& parser) {
     parser.set_optional<int>("t", "threads", 1, "the number of threads to use while generating");
     parser.set_optional<bool>("c", "use_cache", false, "whether to load cache files");
     parser.set_optional<bool>("w", "write_cache", false, "wheather to save cache files");
+    parser.set_optional<bool>("s", "split_cache", false, "wheather to save in sparate cache files per output shape");
 }
 
 int main(int argc, char** argv) {
     cli::Parser parser(argc, argv);
     configure_arguments(parser);
     parser.run_and_exit_if_error();
-    gen(parser.get<int>("n"), parser.get<int>("t"), parser.get<bool>("c"), parser.get<bool>("w"));
+    gen(parser.get<int>("n"), parser.get<int>("t"), parser.get<bool>("c"), parser.get<bool>("w"), parser.get<bool>("s"));
     return 0;
 }

--- a/cpp/src/cubes.cpp
+++ b/cpp/src/cubes.cpp
@@ -162,6 +162,9 @@ Hashy gen(int n, int threads, bool use_cache, bool write_cache, bool split_cache
         hashes.init(n);
         hashes.insert(Cube{{XYZ(0, 0, 0)}}, XYZ(0, 0, 0));
         std::printf("%ld elements for %d\n\r", hashes.size(), n);
+        if (write_cache) {
+            Cache::save("cubes_" + std::to_string(n) + ".bin", hashes, n);
+        }
         return hashes;
     }
 

--- a/cpp/src/cubes.cpp
+++ b/cpp/src/cubes.cpp
@@ -153,8 +153,7 @@ struct Worker {
     }
 };
 
-Hashy gen(int n, int threads, bool use_cache, bool write_cache, bool split_cache) {
-    (void)use_cache;
+FlatCache gen(int n, int threads, bool use_cache, bool write_cache, bool split_cache) {
     Hashy hashes;
     if (n < 1)
         return {};
@@ -165,14 +164,22 @@ Hashy gen(int n, int threads, bool use_cache, bool write_cache, bool split_cache
         if (write_cache) {
             Cache::save("cubes_" + std::to_string(n) + ".bin", hashes, n);
         }
-        return hashes;
+        return FlatCache(hashes, n);
     }
 
     std::string cachefile = "cubes_" + std::to_string(n - 1) + ".bin";
-    CacheReader cr(cachefile);
-    cr.printHeader();
-
-    std::printf("N = %d || generating new cubes from %lu base cubes.\n\r", n, cr.size());
+    CacheReader cr;
+    if (use_cache) {
+        cr.loadFile(cachefile);
+        cr.printHeader();
+    }
+    FlatCache fc;
+    ICache *base = &cr;
+    if (!cr) {
+        fc = gen(n - 1, threads, use_cache, write_cache, false);
+        base = &fc;
+    }
+    std::printf("N = %d || generating new cubes from %lu base cubes.\n\r", n, base->size());
     hashes.init(n);
     uint64_t totalSum = 0;
     auto start = std::chrono::steady_clock::now();
@@ -182,8 +189,8 @@ Hashy gen(int n, int threads, bool use_cache, bool write_cache, bool split_cache
         outShapeCount++;
         XYZ targetShape = tup.first;
         std::printf("process output shape %3d/%d [%2d %2d %2d]\n\r", outShapeCount, totalOutputShapes, targetShape.x(), targetShape.y(), targetShape.z());
-        for (uint32_t sid = 0; sid < cr.numShapes(); ++sid) {
-            auto s = cr.getCubesByShape(sid);
+        for (uint32_t sid = 0; sid < base->numShapes(); ++sid) {
+            auto s = base->getCubesByShape(sid);
             auto &shape = s.shape;
             int diffx = targetShape.x() - shape.x();
             int diffy = targetShape.y() - shape.y();
@@ -236,5 +243,5 @@ Hashy gen(int n, int threads, bool use_cache, bool write_cache, bool split_cache
     std::printf("took %.2f s\033[0K\n\r", dt_ms / 1000.f);
     std::printf("num total cubes: %lu\n\r", totalSum);
     checkResult(n, totalSum);
-    return hashes;
+    return FlatCache(hashes, n);
 }

--- a/cpp/src/newCache.cpp
+++ b/cpp/src/newCache.cpp
@@ -6,12 +6,8 @@
 
 #include <iostream>
 
-CacheReader::CacheReader(const std::string& path)
-    : path_(path), fileDescriptor_(0), fileSize_(0), fileLoaded_(false), dummyHeader{0, 0, 0, 0}, header(&dummyHeader), shapes(0) {
-    if (loadFile(path) != 0) {
-        std::cerr << "failed to load data from \"" << path << "\"" << std::endl;
-    }
-}
+CacheReader::CacheReader() : path_(""), fileDescriptor_(0), fileSize_(0), fileLoaded_(false), dummyHeader{0, 0, 0, 0}, header(&dummyHeader), shapes(0) {}
+
 void CacheReader::printHeader() {
     if (fileLoaded_) {
         printf("magic: %x ", header->magic);
@@ -33,12 +29,12 @@ int CacheReader::printShapes(void) {
     return 0;
 }
 
-int CacheReader::loadFile(std::string path) {
+int CacheReader::loadFile(const std::string path) {
     path_ = path;
     fileDescriptor_ = open(path.c_str(), O_RDONLY);
 
     if (fileDescriptor_ == -1) {
-        std::cerr << "error opening file" << std::endl;
+        std::cerr << "failed to load data from \"" << path << "\"" << std::endl;
         return 1;
     }
 
@@ -66,22 +62,14 @@ int CacheReader::loadFile(std::string path) {
 
 CacheReader::~CacheReader() {
     // unmap file from memory
-    if (munmap(filePointer, fileSize_) == -1) {
-        // error handling
-        std::cerr << "error unmapping file" << std::endl;
-    }
+    if (fileLoaded_) {
+        if (munmap(filePointer, fileSize_) == -1) {
+            // error handling
+            std::cerr << "error unmapping file" << std::endl;
+        }
 
-    // close file descriptor
-    close(fileDescriptor_);
-    fileLoaded_ = false;
+        // close file descriptor
+        close(fileDescriptor_);
+        fileLoaded_ = false;
+    }
 }
-/*
-int main(int argc, char** argv) {
-    CacheReader cr(argv[1]);
-    printf("----------\n");
-    cr.printShapes();
-    printf("---------\n");
-    printf("%d\n", cr.header->numShapes);
-    return 0;
-}
-*/

--- a/cpp/src/newCache.cpp
+++ b/cpp/src/newCache.cpp
@@ -1,0 +1,87 @@
+#include "../include/newCache.hpp"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <iostream>
+
+CacheReader::CacheReader(const std::string& path)
+    : path_(path), fileDescriptor_(0), fileSize_(0), fileLoaded_(false), dummyHeader{0, 0, 0, 0}, header(&dummyHeader), shapes(0) {
+    if (loadFile(path) != 0) {
+        std::cerr << "failed to load data from \"" << path << "\"" << std::endl;
+    }
+}
+void CacheReader::printHeader() {
+    if (fileLoaded_) {
+        printf("magic: %x ", header->magic);
+        printf("n: %d ", header->n);
+        printf("numShapes: %d ", header->numShapes);
+        printf("numPolycubes: %ld\n", header->numPolycubes);
+    } else {
+        printf("no file loaded!\n");
+    }
+}
+
+int CacheReader::printShapes(void) {
+    if (fileLoaded_) {
+        for (uint64_t i = 0; i < header->numShapes; i++) {
+            printf("%d\t%d\t%d\n", shapes[i].dim0, shapes[i].dim1, shapes[i].dim2);
+        }
+        return 1;
+    }
+    return 0;
+}
+
+int CacheReader::loadFile(std::string path) {
+    path_ = path;
+    fileDescriptor_ = open(path.c_str(), O_RDONLY);
+
+    if (fileDescriptor_ == -1) {
+        std::cerr << "error opening file" << std::endl;
+        return 1;
+    }
+
+    // get filesize
+    fileSize_ = lseek(fileDescriptor_, 0, SEEK_END);
+    lseek(fileDescriptor_, 0, SEEK_SET);
+
+    // memory map file
+    filePointer = (uint8_t*)mmap(NULL, fileSize_, PROT_READ, MAP_PRIVATE, fileDescriptor_, 0);
+    if (filePointer == MAP_FAILED) {
+        // error handling
+        std::cerr << "errorm mapping file memory" << std::endl;
+        close(fileDescriptor_);
+        return 2;
+    }
+
+    header = (Header*)(filePointer);
+    shapes = (ShapeEntry*)(filePointer + sizeof(Header));
+    data = (char*)(filePointer + sizeof(Header) + header->numShapes * sizeof(ShapeEntry));
+
+    fileLoaded_ = true;
+
+    return 0;
+}
+
+CacheReader::~CacheReader() {
+    // unmap file from memory
+    if (munmap(filePointer, fileSize_) == -1) {
+        // error handling
+        std::cerr << "error unmapping file" << std::endl;
+    }
+
+    // close file descriptor
+    close(fileDescriptor_);
+    fileLoaded_ = false;
+}
+/*
+int main(int argc, char** argv) {
+    CacheReader cr(argv[1]);
+    printf("----------\n");
+    cr.printShapes();
+    printf("---------\n");
+    printf("%d\n", cr.header->numShapes);
+    return 0;
+}
+*/


### PR DESCRIPTION
This branch splits the problem by output shape. Features:

- Threading rework
- CacheReader with memory mapped file (less Memory usage)
- Output files by output shape (less mem usage, b/c only one set by shape is filled)

Needs:
- review and ideas for better iterators and CubeView which overlays cachefile without copying.
- ~depends on cache files! No independent runs from N=1 to N=X.~
- no merge functionality for splitted cache files yet.

Benchmarks: from N-1

whole output in RAM:
N=13 T=20: 141s (12700H, 16GB) [peak-mem: ~14GB?! don't remember correctly, but was swapping :) ]

only one shape in RAM:
N=13 T=20: 165s (12700H, 16GB) [peak-mem: ~3GB] (slower because clearing hashy is expensive :) )
N=14 T=12: 2500s (AMD 3600, 32GB) [peak-mem: ~24GB]
N=14 T=20: 1936s (12700H, 64GB) [peak-mem: ~24GB]
