### PR TITLE
C++ | fix split cache files

### DIFF
--- a/cpp/include/cache.hpp
+++ b/cpp/include/cache.hpp
@@ -26,6 +26,8 @@ struct Cache {
     };
 
     static void save(std::string path, Hashy& hashes, uint8_t n);
+    // save_split() saves only the given target shape from Hashy
+    static void save_split(std::string path, Hashy& hashes, XYZ target, uint8_t n);
     static Hashy load(std::string path, uint32_t extractShape = ALL_SHAPES);
 
     int filedesc;

--- a/cpp/include/newCache.hpp
+++ b/cpp/include/newCache.hpp
@@ -58,6 +58,7 @@ class CubeIterator {
 
 class ShapeRange {
    public:
+    explicit ShapeRange() {}
     ShapeRange(XYZ* start, XYZ* stop, uint64_t _cubeLen, XYZ _shape)
         : b(_cubeLen, start), e(_cubeLen, stop), size_(((uint64_t)stop - (uint64_t)start) / (_cubeLen * sizeof(XYZ))), shape_(_shape) {}
 

--- a/cpp/src/cubes.cpp
+++ b/cpp/src/cubes.cpp
@@ -261,10 +261,12 @@ FlatCache gen(int n, int threads, bool use_cache, bool write_cache, bool split_c
         }
         if (split_cache) {
             // drop targetShape from Hashy
-            sitr = hashes.byshape.erase(sitr);
-        } else {
-            ++sitr;
+            for (auto &subset : hashes.byshape[targetShape].byhash) {
+                subset.set.clear();
+                subset.set.reserve(1);
+            }
         }
+        ++sitr;
     }
     if (write_cache && !split_cache) {
         Cache::save(base_path + "cubes_" + std::to_string(n) + ".bin", hashes, n);


### PR DESCRIPTION
The split cache files are not saved correctly:
they break the cache file format that states:
`numShapes` <= `numPolycubes` must be true.

The bug is that the `-s`/split_cache is saving
the entire `hashy.byshape` as the shape table for each split cache file but it is not actually removing the targetShape from the hashy.byshape so the saved shape table is too big.

Fix this by saving only the target shape with Cache::save_split() and loading only single shape from split cache files. ~~The targetShape is erased from hashy.byshape~~

The split cache files have to be "boot-strapped" before -u flag is used: Run `cubes -n 5 -w -s` first
Then `cubes -n 6 -w -c -s -u` can continue from this point on step by step.

@bertie2 @nsch0e  please review.

Edit: I ran this further and looks like `cubes -n 11 -w -c -s -u` fails..
I assumed with the fixup that split cache files should contain only single shape, but I don't know if this is the case?

@nsch0e explained that the shape table may contain empty sections, so my `numShapes` <= `numPolycubes` assumption was wrong.