### PR TITLE
Reducing rotations based on bounding box constraint

### DIFF
--- a/python/cubes.py
+++ b/python/cubes.py
@@ -5,7 +5,7 @@ from libraries.cache import get_cache, save_cache, cache_exists
 from libraries.resizing import expand_cube
 from libraries.packing import pack, unpack
 from libraries.renderer import render_shapes
-from libraries.rotation import all_rotations
+from libraries.rotation import all_rotations, one_diff_rot, all_diff_rot
 
 
 def log_if_needed(n, total_n):
@@ -87,11 +87,32 @@ def get_canonical_packing(polycube: np.ndarray,
 
     """
     max_id = b'\x00'
-    for cube_rotation in all_rotations(polycube):
+    shape = polycube.shape
+
+    if shape[0] == shape[1] == shape[2]:
+        for cube_rotation in all_rotations(polycube):
+            this_id = pack(cube_rotation)
+            if this_id in known_ids:
+                return this_id
+            if this_id > max_id:
+                max_id = this_id
+        return max_id
+
+    for idx in range(0, 3):
+        if shape[idx] == shape[(idx + 1) % 3]:
+            for cube_rotation in one_diff_rot(polycube, (idx + 2) % 3, [idx, (idx + 1) % 3]):
+                this_id = pack(cube_rotation)
+                if this_id in known_ids:
+                    return this_id
+                if this_id > max_id:
+                    max_id = this_id
+            return max_id
+
+    for cube_rotation in all_diff_rot(polycube):
         this_id = pack(cube_rotation)
-        if (this_id in known_ids):
+        if this_id in known_ids:
             return this_id
-        if (this_id > max_id):
+        if this_id > max_id:
             max_id = this_id
     return max_id
 

--- a/python/libraries/resizing.py
+++ b/python/libraries/resizing.py
@@ -23,6 +23,52 @@ def crop_cube(cube: np.ndarray) -> np.ndarray:
     return cube
 
 
+def fix_axis(cube):
+    """
+    Rotate cube to make boundary sizes in sorted order.
+
+    Ex : if input cube.shape = (4, 1, 2) this method rotate it to be (1, 2, 4)
+
+    Parameters:
+    cube (np.array): 3D Numpy byte array where 1 values indicate polycube positions
+
+    Returns:
+    np.array: Cropped 3D Numpy byte array equivalent to cube, but with no zero padding
+
+    """
+    if cube.shape == tuple(sorted(cube.shape)):
+        return cube
+
+    if cube.shape == tuple(sorted(cube.shape, reverse=True)):
+        return np.rot90(cube, 1, (0, 2))
+
+    if cube.shape[0] == cube.shape[1] or cube.shape[1] == cube.shape[2]:
+        if cube.shape[0] < cube.shape[2]:
+            return cube
+        else:
+            return np.rot90(cube, 1, (0, 2))
+
+    if cube.shape[0] == cube.shape[2]:
+        if cube.shape[0] < cube.shape[1]:
+            return np.rot90(cube, 1, (1, 2))
+        else:
+            return np.rot90(cube, 1, (0, 1))
+
+    if cube.shape[0] < cube.shape[2] < cube.shape[1]:
+        return np.rot90(cube, 1, (1, 2))
+
+    if cube.shape[1] < cube.shape[2] < cube.shape[0]:
+        return np.rot90(np.rot90(cube, 1, (0, 1)), 1, (1, 2))
+
+    if cube.shape[1] < cube.shape[0] < cube.shape[2]:
+        return np.rot90(cube, 1, (0, 1))
+
+    if cube.shape[2] < cube.shape[0] < cube.shape[1]:
+        return np.rot90(np.rot90(cube, 1, (1, 2)), 1, (0, 1))
+
+    print("error", cube.shape)
+    exit(2)
+
 def expand_cube(cube: np.ndarray) -> Generator[np.ndarray, None, None]:
     """
     Expands a polycube by adding single blocks at all valid locations.
@@ -53,4 +99,4 @@ def expand_cube(cube: np.ndarray) -> Generator[np.ndarray, None, None]:
     for (x, y, z) in zip(exp[0], exp[1], exp[2]):
         new_cube = np.array(cube)
         new_cube[x, y, z] = 1
-        yield crop_cube(new_cube)
+        yield fix_axis(crop_cube(new_cube))

--- a/python/libraries/resizing.py
+++ b/python/libraries/resizing.py
@@ -25,15 +25,15 @@ def crop_cube(cube: np.ndarray) -> np.ndarray:
 
 def fix_axis(cube):
     """
-    Rotate cube to make boundary sizes in sorted order.
+    Rotate cube to make boundary sizes in descending order.
 
-    Ex : if input cube.shape = (4, 1, 2) this method rotate it to be (1, 2, 4)
+    Ex : if input cube.shape = (4, 1, 2) this method rotate it to be (4, 2, 1)
 
     Parameters:
     cube (np.array): 3D Numpy byte array where 1 values indicate polycube positions
 
     Returns:
-    np.array: Cropped 3D Numpy byte array equivalent to cube, but with no zero padding
+    np.array: Rotated 3D Numpy byte array equivalent to cube, but with descending size orientation
 
     """
     if cube.shape == tuple(sorted(cube.shape, reverse=True)):

--- a/python/libraries/rotation.py
+++ b/python/libraries/rotation.py
@@ -4,7 +4,7 @@ from typing import Generator
 
 def all_rotations(polycube: np.ndarray) -> Generator[np.ndarray, None, None]:
     """
-    Calculates all rotations of a polycube.
+    Calculates rotations of a polycube when bounding box size in all axes are equal(Ex (3, 3, 3)).
 
     Adapted from https://stackoverflow.com/questions/33190042/how-to-calculate-all-24-rotations-of-3d-array.
     This function computes all 24 rotations around each of the axis x,y,z. It uses numpy operations to do this, to avoid unecessary copies.
@@ -36,3 +36,47 @@ def all_rotations(polycube: np.ndarray) -> Generator[np.ndarray, None, None]:
     # rotate about axis 2, 8 rotations about axis 1
     yield from single_axis_rotation(np.rot90(polycube, axes=(0, 1)), (0, 2))
     yield from single_axis_rotation(np.rot90(polycube, -1, axes=(0, 1)), (0, 2))
+
+
+def one_diff_rot(cube, diff_axis, equal_axes):
+    """
+    Calculates rotations of a polycube when bounding box size in two axes are equal, but one is different. (Ex (2, 2, 3)).
+    Only 8 rotations can be done without breaking the bounding box.
+
+    Parameters:
+    polycube (np.array): 3D Numpy byte array where 1 values indicate polycube positions
+    diff_axis (integer): Axis which has different size
+    equal_axes (integer array): Axes which have same size
+
+    Returns:
+    generator(np.array): Yields new rotations of this cube about all axes
+
+    """
+    for _ in range(0, 4):
+        yield cube
+        cube = np.rot90(cube, 1, equal_axes)
+
+    cube = np.rot90(cube, 2, (diff_axis, equal_axes[0]))
+
+    for _ in range(0, 4):
+        yield cube
+        cube = np.rot90(cube, 1, equal_axes)
+
+
+def all_diff_rot(cube):
+    """
+    Calculates rotations of a polycube when bounding box size in all axes are different. (Ex (1, 4, 6)).
+    Only 4 rotations can be done without breaking the bounding box.
+
+    Parameters:
+    polycube (np.array): 3D Numpy byte array where 1 values indicate polycube positions
+
+    Returns:
+    generator(np.array): Yields new rotations of this cube about all axes
+
+    """
+    yield cube
+    yield np.rot90(cube, 2, (0, 1))
+    yield np.rot90(cube, 2, (0, 2))
+    yield np.rot90(cube, 2, (1, 2))
+


### PR DESCRIPTION
This change enhance run time performance of python implementation by reducing number of rotations necessary.

The logic is based on bounding box of the new cube shape. Since cube is already cropped we can safely use np.shape as bounding box.

**Performance improvement tested for n = 8**

**Without improvement**
![image](https://github.com/mikepound/opencubes/assets/7001376/12a690cd-fc6a-4111-9c37-592cd577fee9)

**With improvement**
![image](https://github.com/mikepound/opencubes/assets/7001376/214384b0-2d7f-4f7f-853a-5bfbf671d581)

**New steps**
1. After creating expanded cube it is rotated such that np.shape values are sorted order. This will help analyzing cube in later stages.
Ex:
if input cube.shape is (4, 1, 2) it will be rotated into (1, 2, 4)
2. Based on the bounding box possible rotations can be constrained.
As an example lets assume object bounding box size is (1, 2, 4). Any cube has same shape should have same bounding box. So search space should only have objects which contained in (1, 2, 4) bounding box. To keep bounding box constraint cube can be rotated in only 4 ways.

**Following is the list of all possibilities**

1. All axes size is equal
No constraints are possible. Should be validated for 24 rotations.

2. Two axes sizes are equal other axis size is different
Only 8 rotations are possible without breaking bounding box
`for _ in range(0, 4):
        yield cube
        cube = np.rot90(cube, 1, equal_axes)

    cube = np.rot90(cube, 2, (diff_axis, equal_axes[0]))

    for _ in range(0, 4):
        yield cube
        cube = np.rot90(cube, 1, equal_axes)`

3. All axes sizes are different.
Only 4 rotations are possible without breaking bounding box.
    yield cube
    yield np.rot90(cube, 2, (0, 1))
    yield np.rot90(cube, 2, (0, 2))
    yield np.rot90(cube, 2, (1, 2))